### PR TITLE
Add default dependabot.yml for GitHub action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
According to <https://www.reddit.com/r/devops/comments/xvh9t1/common_github_dependabot_file_across_org/> this is not documented but may apply to all repos in the organization. If it doesn't, this can be removed again.
<https://devopsjournal.io/blog/2021/11/26/GitHub-magic-files> lists .github repo support GitHub config files but for dependabot.yml the field is blank (unknown).